### PR TITLE
Travisci

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wiki"]
-	path = wiki
-	url = git@bitbucket.org:kassonlab/gromacs_api.git/wiki

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,40 @@
 language: cpp
+sudo: false
+
+matrix:
+
+  include:
+
+  - os: linux
+    compiler: gcc
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - doxygen
+        - python
+        - libmpich-dev
+        - libxml2-dev
+        - libblas-dev
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - g++-6
+        - gcc-6
+    env:
+      - GMX_DOUBLE=OFF
+      - GMX_MPI=OFF
+      - GMX_THREAD_MPI=ON
 
 before_install:
- - echo "yes" | sudo add-apt-repository ppa:kalakris/cmake #https://github.com/travis-ci/travis-ci/issues/2212
- - sudo apt-get update
- - sudo apt-get install libfftw3-dev libopenmpi-dev libx11-dev zlib1g-dev libgsl0-dev libxml2-dev libblas-dev liblapack-dev libboost-dev cmake
+  - uname -a
+  - apt list --installed
+  - dpkg-query -L doxygen
+  - test -n $CC  && unset CC
+  - test -n $CXX && unset CXX
 
-env:
-  matrix:
-    - GMX_DOUBLE=OFF GMX_MPI=OFF
-    - GMX_DOUBLE=OFF GMX_MPI=ON
-    - GMX_DOUBLE=ON  GMX_MPI=OFF
-    - GMX_DOUBLE=ON  GMX_MPI=ON
+script:
+  - mkdir build && pushd build && cmake -DBUILD_TESTING=ON -DGMX_BUILD_OWN_FFTW=ON -DGMX_DOUBLE=$GMX_DOUBLE -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI .. && make -j4
+  - make check
 
-script: 
-  - mkdir build && pushd build && cmake -DGMX_DOUBLE=$GMX_DOUBLE -DGMX_MPI=$GMX_MPI .. && make -j4
-
-compiler:
-  - clang
-  - gcc

--- a/src/api/cpp/tests/CMakeLists.txt
+++ b/src/api/cpp/tests/CMakeLists.txt
@@ -58,9 +58,13 @@ target_link_libraries(gmxapi-mpi-test Gromacs::gmxapi)
 
 gmx_register_gtest_test(GmxapiMpiTests gmxapi-mpi-test MPI_RANKS 2 INTEGRATION_TEST)
 
-set_tests_properties(GmxapiMpiTests PROPERTIES
-                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
+if(BUILD_TESTING)
+    # Apparently gmx_register_gtest_test has some conditional like the following when MPI_RANKS is setor when gmx_add_gtest_executable has MPI set.
+    if(GMX_MPI OR GMX_THREAD_MPI)
+        set_tests_properties(GmxapiMpiTests PROPERTIES
+                             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    endif(GMX_MPI OR GMX_THREAD_MPI)
+endif()
 
 # If we want to override the API version in the version.h for testing purposes, we'll do it another way...
 #target_compile_definitions(gmxapi-test PUBLIC


### PR DESCRIPTION
Perform integration testing with Travis-CI.

The .travis.yml file and CMake updates should provide passing Travis-CI builds.