### PR TITLE
update for ensemble reduce

### DIFF
--- a/src/api/cpp/context.cpp
+++ b/src/api/cpp/context.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include <cassert>
+#include <vector>
 #include "programs/mdrun/runner.h"
 #include "gromacs/mdtypes/tpxstate.h"
 
@@ -81,6 +82,8 @@ class ContextImpl
          */
         std::shared_ptr<Status> status_;
         std::weak_ptr<Session> session_;
+
+        std::vector<std::string> _mdArgs;
 };
 
 ContextImpl::ContextImpl() :
@@ -120,7 +123,7 @@ std::shared_ptr<Session> ContextImpl::launch(std::shared_ptr<ContextImpl> contex
         {
             auto tpxState = gmx::TpxState::initializeFromFile(filename);
             newMdRunner->setTpx(std::move(tpxState));
-            newMdRunner->initFromAPI();
+            newMdRunner->initFromAPI(_mdArgs);
         }
 
         {

--- a/src/api/cpp/context.cpp
+++ b/src/api/cpp/context.cpp
@@ -42,6 +42,8 @@ class warn
         const char* message_;
 };
 
+using gmxapi::MDArgs;
+
 /*!
  * \brief Context implementation base class.
  *
@@ -83,7 +85,7 @@ class ContextImpl
         std::shared_ptr<Status> status_;
         std::weak_ptr<Session> session_;
 
-        std::vector<std::string> _mdArgs;
+        MDArgs mdArgs_;
 };
 
 ContextImpl::ContextImpl() :
@@ -123,7 +125,7 @@ std::shared_ptr<Session> ContextImpl::launch(std::shared_ptr<ContextImpl> contex
         {
             auto tpxState = gmx::TpxState::initializeFromFile(filename);
             newMdRunner->setTpx(std::move(tpxState));
-            newMdRunner->initFromAPI(_mdArgs);
+            newMdRunner->initFromAPI(mdArgs_);
         }
 
         {
@@ -166,6 +168,11 @@ Context::Context(std::shared_ptr<ContextImpl> &&impl) :
     impl_{std::move(impl)}
 {
     assert(impl_ != nullptr);
+}
+
+void Context::setMDArgs(const MDArgs &mdArgs)
+{
+    impl_->mdArgs_ = mdArgs;
 }
 
 Context::~Context() = default;

--- a/src/api/cpp/gmxapi/context.h
+++ b/src/api/cpp/gmxapi/context.h
@@ -8,7 +8,8 @@
 
 
 #include <memory>
-
+#include <vector>
+#include <string>
 
 namespace gmxapi
 {

--- a/src/api/cpp/gmxapi/context.h
+++ b/src/api/cpp/gmxapi/context.h
@@ -9,12 +9,14 @@
 
 #include <memory>
 
+
 namespace gmxapi
 {
 
 class Status;
 class Workflow;
 class Session;
+using MDArgs = std::vector<std::string>;
 
 /*!
  * \brief Context implementation abstract base class.
@@ -72,6 +74,17 @@ class Context
 
         //! Construct by wrapping an implementation object.
         explicit Context(std::shared_ptr<ContextImpl> &&impl);
+
+        /*!
+         * \brief Set the simulation runtime arguments for this instance.
+         *
+         * \param mdArgs User-provided runtime parameters a la mdrun CLI
+         *
+         * This is awkwardly named and due for some evolution, since most of the mdrun CLI options pertain
+         * to the execution environment rather than the simulation parameters. For the first implementation,
+         * we just map user arguments to the equivalent command-line substrings.
+         */
+        void setMDArgs(const MDArgs& mdArgs);
 
         /*!
          * \brief Launch a workflow in the current context, if possible.

--- a/src/api/cpp/gmxapi/system.h
+++ b/src/api/cpp/gmxapi/system.h
@@ -63,7 +63,8 @@ class System final
         /// \endcond
 
         Status setRestraint(std::shared_ptr<gmxapi::MDModule> module);
-        // Note there is confusing overlap in the use of these two functions that should be normalized.
+
+        // \todo This is used in gmxpy but not tested here.
         std::shared_ptr<MDWorkSpec> getSpec();
 
         /*!

--- a/src/gromacs/restraint/restraintpotential.cpp
+++ b/src/gromacs/restraint/restraintpotential.cpp
@@ -99,4 +99,13 @@ const struct pull_t *LegacyPuller::getRaw() const
     return pullWorkPointer_;
 }
 
+void IRestraintPotential::update(gmx::Vector v,
+                                 gmx::Vector v0,
+                                 double t)
+{
+    // By default, an IRestraintPotential has a null updater.
+    (void)(v);
+    (void)(v0);
+    (void)(t);
+}
 } // end namespace gmx

--- a/src/gromacs/restraint/restraintpotential.h
+++ b/src/gromacs/restraint/restraintpotential.h
@@ -205,6 +205,12 @@ class IRestraintPotential
                               Vector r2,
                               double t) = 0;
 
+
+        // An update function to be called on the simulation master rank/thread periodically by the Restraint framework.
+        virtual void update(gmx::Vector v,
+                            gmx::Vector v0,
+                            double t);
+
         virtual /*!
          * \brief Find out what sites this restraint is configured to act on.
          * \return

--- a/src/programs/mdrun/runner.cpp
+++ b/src/programs/mdrun/runner.cpp
@@ -1130,6 +1130,7 @@ int Mdrunner::mdrunner()
 
     // Build modules on all threads.
     {
+        // Build restraints.
         // Currently there is at most one restraint modules.
         auto puller = restraintManager_->getSpec();
         if (puller != nullptr)

--- a/src/programs/mdrun/runner.h
+++ b/src/programs/mdrun/runner.h
@@ -47,9 +47,11 @@
 
 #include <array>
 #include <memory>
+#include <vector>
+#include <string>
 #include <mutex>
-#include "gromacs/commandline/pargs.h"
 #include <bitset>
+#include "gromacs/commandline/pargs.h"
 
 #include "gromacs/commandline/filenm.h"
 #include "gromacs/hardware/hw_info.h"

--- a/src/programs/mdrun/runner.h
+++ b/src/programs/mdrun/runner.h
@@ -243,7 +243,7 @@ class Mdrunner
         void initFromCLI(int argc, char *argv[]);
 
         //! Set up mdrun with parameters provided by API instead of CLI.
-        void initFromAPI();
+        void initFromAPI(const std::vector<std::string>& args);
 
         /*! \brief Driver routine, that calls the different simulation methods.
          *


### PR DESCRIPTION
Allow the restraint framework to make a call-back exclusively to the simulation master rank. This allows a thread-MPI ensemble to use an external ensemble resource periodically with exactly one participating thread per ensemble simulation member.