### PR TITLE
Reduce

### DIFF
--- a/src/api/cpp/session.cpp
+++ b/src/api/cpp/session.cpp
@@ -94,6 +94,7 @@ Status SessionImpl::run() noexcept
 {
     // Status is failure until proven otherwise.
     Status status{false};
+    assert(runner_ != nullptr);
     auto rc = runner_->mdrunner();
     if (rc == 0)
     {

--- a/src/api/cpp/tests/test_restraint.cpp
+++ b/src/api/cpp/tests/test_restraint.cpp
@@ -28,10 +28,13 @@ class NullRestraint : public gmx::IRestraintPotential
                                          gmx::Vector r2,
                                          double t) override
         {
+            (void)r1;
+            (void)r2;
+            (void)t;
             return {};
         }
 
-        std::array<unsigned long, 2> sites() const override
+        std::vector<unsigned long> sites() const override
         {
             return {{0,1}};
         }

--- a/src/gromacs/restraint/manager.cpp
+++ b/src/gromacs/restraint/manager.cpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <map>
 #include <iostream>
+#include <mutex>
 
 #include "restraintfunctor-impl.h"
 

--- a/src/gromacs/restraint/restraintmdmodule-impl.h
+++ b/src/gromacs/restraint/restraintmdmodule-impl.h
@@ -49,12 +49,111 @@ class Site
          *
          * \param globalIndex Atom index in the global state (as input to the simulation)
          */
-        explicit Site(unsigned long int globalIndex) : index_{globalIndex} {};
+        explicit Site(unsigned long int globalIndex) :
+            index_{globalIndex},
+            t_{0.},
+            r_{0, 0, 0}
+        {};
+
+        // Explicitly define copies. Implicit definition is not possible because of the mutex member,
+        // and a copy constructor is necessary to use Site in a std::vector. Really, we should make
+        // a copy point to the same implementation object to reuse its cache.
+        Site(const Site& site) :
+            index_{site.index_},
+            t_{site.t_},
+            r_{site.r_},
+            cacheMutex_{}
+        {}
+        // Assignment doesn't make sense because it implies that a site's meaning is fuzzy.
+        // If the definition of a site is changing, just make a new site. There's nothing to be gained
+        // by reusing one or by creating it uninitialized.
+        Site& operator=(const Site& site) = delete;
 
         unsigned long int index() const {return index_;};
 
+        /*!
+         * \brief Get the position of this site at time t.
+         *
+         * By providing the current time, we can cache results in order to use them once per timestep.
+         * In the long term, we would prefer to also allow client code to preregister interest in a
+         * position at a given time, or issue "futures".
+         *
+         * \param cr Communications record.
+         * \param nx Number of locally available atoms (size of local atom data arrays)
+         * \param x Array of locally available atom coordinates.
+         * \param t the current time.
+         * \return position vector.
+         */
+        RVec position(const t_commrec *cr, size_t nx, const rvec* x, double t)
+        {
+            // I think I'm overlooking a better way to do this, but I think we should move to an issuer
+            // of futures instead of explicitly locking, so it might not be worth looking into. I'm trying
+            // to avoid locking the mutex if possible, but if we wait for a lock, we might perform the
+            // cache update several times, and yet it would be nice not to have to make any lock at all
+            // if the cache is already up-to-date. The other thing we can do is to require that someone
+            // trigger the Sites update at the global atom position update(s) and make it an error to
+            // request site positions for the wrong time, since it is likely that all threads will request
+            // site position data at almost exactly the same time. Finally, we could just use a barrier,
+            // but then we have to make assumptions or keep track of which threads are interested.
+            // Also, we should manage all sites at once instead of one at a time.
+            if(t_ <= t) // Do we need to update the cache?
+            {
+                std::lock_guard<std::mutex> cacheLock(cacheMutex_);
+                // Now that we've got the lock, check again whether the cache was updated while we were waiting.
+                if (t_ <= t)
+                {
+                    gmx::RVec r{0,0,0};
+                    if (cr != nullptr && DOMAINDECOMP(cr)) // Domain decomposition
+                    {
+                        // Get global-to-local indexing structure
+                        auto crossRef = cr->dd->ga2la;
+                        assert(crossRef != nullptr);
+                        int localIndex{-1};
+                        if (ga2la_get_home(crossRef,
+                                           static_cast<int>(index_),
+                                           &localIndex))
+                        {
+                            assert(localIndex < static_cast<decltype(localIndex)>(nx));
+                            assert(localIndex >= 0);
+                            // If atom is local, get its location
+                            copy_rvec(x[localIndex], r);
+                        }
+                        else
+                        {
+                            // Nothing to contribute on this rank. Leave position == [0,0,0].
+                        }
+                        // AllReduce across the ranks of the simulation.
+                        std::array<double , 3> buffer{{r[0], r[1], r[2]}};
+                        // \todo This definitely needs some abstraction and checks.
+                        // This should be an all-reduce sum, which gmx_sumd appears to be.
+                        gmx_sumd(3, buffer.data(), cr);
+                        r[0] = static_cast<real>(buffer[0]);
+                        r[1] = static_cast<real>(buffer[1]);
+                        r[2] = static_cast<real>(buffer[2]);
+
+                    } // end domain decomposition branch
+                    else
+                    {
+                        // No DD so all atoms are local.
+                        copy_rvec(x[index_], r);
+                    }
+                    // Update cache and cache status.
+                    copy_rvec(r, r_);
+                    t_ = t;
+                } // end inner check if (t_ <= t)
+                // else the cache was updated while we were waiting for the lock. We're done here.
+                // release lock at end of block.
+            } // end outer check if (t_ <= t)
+
+            return r_;
+        }
+
     private:
-        unsigned long int index_;
+        /// global index of the single-atom site.
+        const unsigned long int index_;
+        volatile double t_;
+        RVec r_;
+        std::mutex cacheMutex_;
 };
 
 } //end anonymous namespace
@@ -128,8 +227,7 @@ class RestraintForceProvider : public gmx::IForceProvider
          * \param restraint
          */
         explicit RestraintForceProvider(std::shared_ptr<gmx::IRestraintPotential> restraint,
-                                        unsigned long int site1,
-                                        unsigned long int site2);
+                                        const std::vector<unsigned long int>& sites);
 
         /*!
          * \brief Implement the IForceProvider interface.
@@ -148,7 +246,10 @@ class RestraintForceProvider : public gmx::IForceProvider
          * The right optimization will depend on how the code is being used, but I expect allocating and reusing even
          * large arrays for lookup tables and calculation staging areas will be effective.
          *
-         * Call the evaluator(s) for the restraints for the configured
+         * Call the evaluator(s) for the restraints for the configured sites. Forces are applied to atoms in the first
+         * and last site listed. Intermediate sites are used as reference coordinates when the relevant vector between
+         * sites is on the order of half a box length or otherwise ambiguous in the case of periodic boundary conditions.
+         *
          * \param cr
          * \param mdatoms
          * \param box
@@ -165,97 +266,47 @@ class RestraintForceProvider : public gmx::IForceProvider
 
         override
         {
+            using gmx::detail::vec3;
             using gmx::detail::make_vec3;
 
             assert(restraint_ != nullptr);
-            const auto site1 = static_cast<size_t>(site1_.index());
-            const auto site2 = static_cast<size_t>(site2_.index());
+
+            assert(mdatoms->homenr >= 0);
+
+            assert(check_box(-1, box) == nullptr);
+            t_pbc pbc{};
+            set_pbc(&pbc, -1, box);
 
             // Cooperatively get Cartesian coordinates for center of mass of each site
-            RVec r1{0,0,0};
-            RVec r2{0,0,0};
-            if (cr->dd != nullptr)
+            RVec r1 = sites_[0].position(cr,
+                                      static_cast<size_t>(mdatoms->homenr),
+                                      x,
+                                      t);
+            RVec r2{r1[0],r1[1],r1[2]};
+            rvec dr{0,0,0};
+            // Build r2 by following a path of difference vectors that are each presumed to be less than
+            // a half-box apart, in case we are battling periodic boundary conditions along the lines of
+            // a big molecule in a small box.
+            for (size_t i = 0; i < sites_.size() - 1; ++i)
             {
-                // Get global-to-local indexing structure
-                auto crossRef = cr->dd->ga2la;
-                assert(crossRef != nullptr);
-                int localIndex{-1};
-                if (ga2la_get_home(crossRef,
-                                   static_cast<int>(site1),
-                                   &localIndex))
-                {
-                    assert(localIndex < mdatoms->homenr);
-                    assert(localIndex >= 0);
-                    // If atom is local, get its location
-                    copy_rvec(x[localIndex], r1);
-                }
-                else
-                {
-                    // leave position == [0,0,0]
-                }
-                if (ga2la_get_home(crossRef,
-                                   static_cast<int>(site2),
-                                   &localIndex))
-                {
-                    assert(localIndex < mdatoms->homenr);
-                    assert(localIndex >= 0);
-                    // If atom is local, get its location
-                    copy_rvec(x[localIndex], r2);
-                }
-                else
-                {
-                    // leave position == [0,0,0]
-                }
+                RVec a = sites_[i].position(cr,
+                                            static_cast<size_t>(mdatoms->homenr),
+                                            x,
+                                            t);
+                RVec b = sites_[i+1].position(cr,
+                                              static_cast<size_t>(mdatoms->homenr),
+                                              x,
+                                              t);
+                pbc_dx(&pbc, b, a, dr);
+                r2[0] += dr[0];
+                r2[1] += dr[1];
+                r2[2] += dr[2];
             }
-            else
-            {
-                // No DD so all atoms are local.
-                copy_rvec(x[site1], r1);
-                copy_rvec(x[site2], r2);
-            }
-            // r1 and r2 are now correct if local or [0,0,0] if not local.
-
-            if (cr != nullptr && DOMAINDECOMP(cr))
-            {
-                // our quick-and-dirty short-term solution just relies on getting non-zero positions on exactly one ranks
-                std::array<double, 6> buffer {{static_cast<double>(r1[0]),
-                                                  static_cast<double>(r1[1]),
-                                                  static_cast<double>(r1[2]),
-                                                  static_cast<double>(r2[0]),
-                                                  static_cast<double>(r2[1]),
-                                                  static_cast<double>(r2[2]),
-                                              }};
-                // \todo This definitely needs some abstraction and checks.
-                // This should be an all-reduce sum...
-                gmx_sumd(6, buffer.data(), cr);
-                assert((r1[0] == 0) || (buffer[0] == r1[0]));
-                assert((r1[1] == 0) || (buffer[1] == r1[1]));
-                assert((r1[2] == 0) || (buffer[2] == r1[2]));
-                assert((r2[0] == 0) || (buffer[3] == r2[0]));
-                assert((r2[1] == 0) || (buffer[4] == r2[1]));
-                assert((r2[2] == 0) || (buffer[5] == r2[2]));
-                r1[0] = static_cast<real>(buffer[0]);
-                r1[1] = static_cast<real>(buffer[1]);
-                r1[2] = static_cast<real>(buffer[2]);
-                r2[0] = static_cast<real>(buffer[3]);
-                r2[1] = static_cast<real>(buffer[4]);
-                r2[2] = static_cast<real>(buffer[5]);
-            }
-
-            // Apply minimum image convention to get into the same coordinate system.
-            // \todo allow reference site for distances greater than half a box length.
-            // \todo make conditional on what the implemented potential wants.
-            {
-                assert(check_box(-1, box) == nullptr);
-                RVec dx{0,0,0};
-                t_pbc pbc{};
-                set_pbc(&pbc, -1, box);
-                pbc_dx(&pbc, r2, r1, dx);
-                rvec_add(r1, dx, r2);
-            }
+            // In the case of a single-atom site, r1 and r2 are now correct if local or [0,0,0] if not local.
 
 
-            // Master rank update call-back
+            // Master rank update call-back. This needs to be moved to a discrete place in the
+            // time step to avoid extraneous barriers. The code would be prettier with "futures"...
             if ((cr->dd == nullptr) || MASTER(cr))
             {
                 restraint_->update(make_vec3<real>(r1[0],
@@ -266,9 +317,12 @@ class RestraintForceProvider : public gmx::IForceProvider
                                                    r2[2]),
                                    t);
             }
+            // All ranks wait for the update to finish.
             // tMPI ranks are depending on structures that may have just been updated.
             if (cr != nullptr && DOMAINDECOMP(cr))
             {
+                // Note: this assumes that all ranks are hitting this line, which is not generally true.
+                // I need to find the right subcommunicator. What I really want is a _scoped_ communicator...
                 gmx_barrier(cr);
             }
 
@@ -276,15 +330,16 @@ class RestraintForceProvider : public gmx::IForceProvider
                                                make_vec3<real>(r2[0], r2[1], r2[2]),
                                                t);
 
-            size_t aLocal{site1};
+            int site1{static_cast<int>(sites_.front().index())};
+            int aLocal{site1};
             // Set forces using index a if no domain decomposition, otherwise set with local index if available.
             if ((cr->dd == nullptr) || ga2la_get_home(cr->dd->ga2la,
-                               static_cast<int>(site1),
-                               reinterpret_cast<int*>(&aLocal)))
+                               site1,
+                               &aLocal))
             {
-                force[aLocal][0] += result.force.x;
-                force[aLocal][1] += result.force.y;
-                force[aLocal][2] += result.force.z;
+                force[static_cast<size_t>(aLocal)][0] += result.force.x;
+                force[static_cast<size_t>(aLocal)][1] += result.force.y;
+                force[static_cast<size_t>(aLocal)][2] += result.force.z;
             }
 
             // Note: Currently calculateForces is called once per restraint and each restraint
@@ -292,39 +347,43 @@ class RestraintForceProvider : public gmx::IForceProvider
             // with possibly duplicated sites, in which case we may prefer to iterate over non-frozen
             // sites to apply forces without explicitly expressing pairwise symmetry as in the
             // following logic.
-            size_t bLocal{site2};
+            int site2{static_cast<int>(sites_.back().index())};
+            int bLocal{site2};
             if ((cr->dd == nullptr) || ga2la_get_home(cr->dd->ga2la,
-                               static_cast<int>(site2),
-                               reinterpret_cast<int*>(&bLocal)))
+                               site2,
+                               &bLocal))
             {
-                force[bLocal][0] -= result.force.x;
-                force[bLocal][1] -= result.force.y;
-                force[bLocal][2] -= result.force.z;
+                force[static_cast<size_t>(bLocal)][0] -= result.force.x;
+                force[static_cast<size_t>(bLocal)][1] -= result.force.y;
+                force[static_cast<size_t>(bLocal)][2] -= result.force.z;
             }
 
             if (int(t*1000) % 100 == 0)
             {
                 if ((cr->dd == nullptr) || MASTER(cr))
                 {
-                    std::cout << "Evaluated restraint forces on atoms at " << make_vec3<real>(r1[0], r1[1], r1[2]) << " and " << make_vec3<real>(r2[0], r2[1], r2[2]) << ": " << result.force << ". rank,time: " << cr->rank_pp_intranode << "," << t << "\n";
+                    std::cout << "Evaluated restraint forces on sites at " << make_vec3<real>(r1[0], r1[1], r1[2]) << " and " << make_vec3<real>(r2[0], r2[1], r2[2]) << ": " << result.force << ". rank,time: " << cr->rank_pp_intranode << "," << t << "\n";
                 }
             }
 
         }
     private:
         std::shared_ptr<gmx::IRestraintPotential> restraint_;
-        Site site1_;
-        Site site2_;
+        std::vector<Site> sites_;
 };
 
 RestraintForceProvider::RestraintForceProvider(std::shared_ptr<gmx::IRestraintPotential> restraint,
-                                               unsigned long int site1,
-                                               unsigned long int site2) :
+                                               const std::vector<unsigned long int>& sites) :
     restraint_{std::move(restraint)},
-    site1_{site1},
-    site2_{site2}
+    sites_{}
 {
     assert(restraint_ != nullptr);
+    assert(sites_.empty());
+    for (auto&& site : sites)
+    {
+        sites_.emplace_back(site);
+    }
+    assert(sites_.size() >= 2);
 }
 
 /*! \internal
@@ -339,14 +398,13 @@ class RestraintMDModuleImpl final: public gmx::IMDModule
     public:
         RestraintMDModuleImpl() = delete;
         RestraintMDModuleImpl(std::shared_ptr<gmx::IRestraintPotential>,
-                              unsigned long int site1,
-                              unsigned long int site2);
+                              const std::vector<unsigned long int>& sites);
 
         // Does default move work right (exception safe) with multiple unique_ptr members?
         RestraintMDModuleImpl(RestraintMDModuleImpl&&) noexcept = default;
         RestraintMDModuleImpl& operator=(RestraintMDModuleImpl&&) noexcept = default;
 
-        virtual ~RestraintMDModuleImpl();
+        ~RestraintMDModuleImpl() override;
 
         IMdpOptionProvider *mdpOptionProvider() override;
 

--- a/src/gromacs/restraint/restraintmdmodule-impl.h
+++ b/src/gromacs/restraint/restraintmdmodule-impl.h
@@ -15,6 +15,7 @@
 #include "restraintpotential.h"
 
 #include <iostream>
+#include <mutex>
 
 #include "gromacs/domdec/domdec_struct.h"
 #include "gromacs/domdec/ga2la.h"

--- a/src/gromacs/restraint/restraintmdmodule.cpp
+++ b/src/gromacs/restraint/restraintmdmodule.cpp
@@ -10,9 +10,8 @@
 gmx::RestraintMDModuleImpl::~RestraintMDModuleImpl() = default;
 
 gmx::RestraintMDModuleImpl::RestraintMDModuleImpl(std::shared_ptr<gmx::IRestraintPotential> restraint,
-                                                  unsigned long int site1,
-                                                  unsigned long int site2) :
-    forceProvider_{::gmx::compat::make_unique<RestraintForceProvider>(restraint, site1, site2)},
+                                                  const std::vector<unsigned long int>& sites) :
+    forceProvider_{::gmx::compat::make_unique<RestraintForceProvider>(restraint, sites)},
     outputProvider_{::gmx::compat::make_unique<RestraintOutputProvider>()},
     optionProvider_{::gmx::compat::make_unique<RestraintOptionProvider>()}
 {
@@ -65,9 +64,9 @@ void gmx::RestraintMDModule::initForceProviders(ForceProviders *forceProviders)
 }
 
 std::unique_ptr<gmx::RestraintMDModule>
-gmx::RestraintMDModule::create(std::shared_ptr<gmx::IRestraintPotential> restraint, unsigned long int site1, unsigned long int site2)
+gmx::RestraintMDModule::create(std::shared_ptr<gmx::IRestraintPotential> restraint, const std::vector<unsigned long int>& sites)
 {
-    auto implementation = ::gmx::compat::make_unique<RestraintMDModuleImpl>(std::move(restraint), site1, site2);
+    auto implementation = ::gmx::compat::make_unique<RestraintMDModuleImpl>(std::move(restraint), sites);
     std::unique_ptr<gmx::RestraintMDModule> newModule{new RestraintMDModule(std::move(implementation))};
     return newModule;
 }

--- a/src/gromacs/restraint/restraintmdmodule.cpp
+++ b/src/gromacs/restraint/restraintmdmodule.cpp
@@ -7,6 +7,144 @@
 #include "restraintmdmodule.h"
 #include "restraintmdmodule-impl.h"
 
+
+gmx::RestraintForceProvider::RestraintForceProvider(std::shared_ptr<gmx::IRestraintPotential> restraint,
+                                               const std::vector<unsigned long int>& sites) :
+    restraint_{std::move(restraint)},
+    sites_{}
+{
+    assert(restraint_ != nullptr);
+    assert(sites_.empty());
+    for (auto&& site : sites)
+    {
+        sites_.emplace_back(site);
+    }
+    assert(sites_.size() >= 2);
+}
+
+void gmx::RestraintForceProvider::calculateForces(const t_commrec          *cr,
+                                                  const t_mdatoms          *mdatoms,
+                                                  const matrix              box,
+                                                  double                    t,
+                                                  const rvec               *x,
+                                                  gmx::ArrayRef<gmx::RVec>  force)
+{
+    using gmx::detail::vec3;
+    using gmx::detail::make_vec3;
+
+    assert(restraint_ != nullptr);
+
+    assert(mdatoms->homenr >= 0);
+
+    assert(check_box(-1, box) == nullptr);
+    t_pbc pbc{};
+    set_pbc(&pbc, -1, box);
+
+    // Cooperatively get Cartesian coordinates for center of mass of each site
+    RVec r1 = sites_[0].centerOfMass(cr,
+                                     static_cast<size_t>(mdatoms->homenr),
+                                     x,
+                                     t);
+    // r2 is to be constructed as
+    // r2 = (site[N] - site[N-1]) + (site_{N-1} - site_{N-2}) + ... + (site_2 - site_1) + site_1
+    // where the minimum image convention is applied to each path but not to the overall sum.
+    // It is redundant to pass both r1 and r2 to called code, and potentially confusing, since
+    // r1 may refer to an actual coordinate in the simulation while r2 may be in an expanded
+    // Cartesian coordinate system. Called code should not use r1 and r2 to attempt to identify
+    // sites in the simulation. If we need that functionality, we should do it separately by
+    // allowing called code to look up atoms by tag or global index.
+    RVec r2{r1[0],r1[1],r1[2]};
+    rvec dr{0,0,0};
+    // Build r2 by following a path of difference vectors that are each presumed to be less than
+    // a half-box apart, in case we are battling periodic boundary conditions along the lines of
+    // a big molecule in a small box.
+    for (size_t i = 0; i < sites_.size() - 1; ++i)
+    {
+        RVec a = sites_[i].centerOfMass(cr,
+                                        static_cast<size_t>(mdatoms->homenr),
+                                        x,
+                                        t);
+        RVec b = sites_[i + 1].centerOfMass(cr,
+                                            static_cast<size_t>(mdatoms->homenr),
+                                            x,
+                                            t);
+        // dr = minimum_image_vector(b - a)
+        pbc_dx(&pbc, b, a, dr);
+        r2[0] += dr[0];
+        r2[1] += dr[1];
+        r2[2] += dr[2];
+    }
+    // In the case of a single-atom site, r1 and r2 are now correct if local or [0,0,0] if not local.
+
+
+    // Master rank update call-back. This needs to be moved to a discrete place in the
+    // time step to avoid extraneous barriers. The code would be prettier with "futures"...
+    if ((cr->dd == nullptr) || MASTER(cr))
+    {
+        restraint_->update(make_vec3<real>(r1[0],
+                                           r1[1],
+                                           r1[2]),
+                           make_vec3<real>(r2[0],
+                                           r2[1],
+                                           r2[2]),
+                           t);
+    }
+    // All ranks wait for the update to finish.
+    // tMPI ranks are depending on structures that may have just been updated.
+    if (cr != nullptr && DOMAINDECOMP(cr))
+    {
+        // Note: this assumes that all ranks are hitting this line, which is not generally true.
+        // I need to find the right subcommunicator. What I really want is a _scoped_ communicator...
+        gmx_barrier(cr);
+    }
+
+    // Apply restraint on all thread ranks only after any updates have been made.
+    auto result = restraint_->evaluate(make_vec3<real>(r1[0], r1[1], r1[2]),
+                                       make_vec3<real>(r2[0], r2[1], r2[2]),
+                                       t);
+
+    // This can easily be generalized for pair restraints that apply to selections instead of
+    // individual indices, or to restraints that aren't pair restraints.
+    int site1{static_cast<int>(sites_.front().index())};
+    int aLocal{site1};
+    // Set forces using index a if no domain decomposition, otherwise set with local index if available.
+    if ((cr->dd == nullptr) || ga2la_get_home(cr->dd->ga2la,
+                                              site1,
+                                              &aLocal))
+    {
+        force[static_cast<size_t>(aLocal)][0] += result.force.x;
+        force[static_cast<size_t>(aLocal)][1] += result.force.y;
+        force[static_cast<size_t>(aLocal)][2] += result.force.z;
+    }
+
+    // Note: Currently calculateForces is called once per restraint and each restraint
+    // applies to a pair of atoms. Future optimizations may consolidate multiple restraints
+    // with possibly duplicated sites, in which case we may prefer to iterate over non-frozen
+    // sites to apply forces without explicitly expressing pairwise symmetry as in the
+    // following logic.
+    int site2{static_cast<int>(sites_.back().index())};
+    int bLocal{site2};
+    if ((cr->dd == nullptr) || ga2la_get_home(cr->dd->ga2la,
+                                              site2,
+                                              &bLocal))
+    {
+        force[static_cast<size_t>(bLocal)][0] -= result.force.x;
+        force[static_cast<size_t>(bLocal)][1] -= result.force.y;
+        force[static_cast<size_t>(bLocal)][2] -= result.force.z;
+    }
+
+    // Kludgey logging for sanity checking until we can be passed a logging facility.
+    // I suppose we could use MDOutputProvider for this, but we don't necessarily want it
+    // in a log file.
+    if (int(t*1000) % 100 == 0)
+    {
+        if ((cr->dd == nullptr) || MASTER(cr))
+        {
+            std::cout << "Evaluated restraint forces on sites at " << make_vec3<real>(r1[0], r1[1], r1[2]) << " and " << make_vec3<real>(r2[0], r2[1], r2[2]) << ": " << result.force << ". rank,time: " << cr->rank_pp_intranode << "," << t << "\n";
+        }
+    }
+}
+
 gmx::RestraintMDModuleImpl::~RestraintMDModuleImpl() = default;
 
 gmx::RestraintMDModuleImpl::RestraintMDModuleImpl(std::shared_ptr<gmx::IRestraintPotential> restraint,

--- a/src/gromacs/restraint/restraintmdmodule.h
+++ b/src/gromacs/restraint/restraintmdmodule.h
@@ -45,7 +45,7 @@ class RestraintMDModule final : public gmx::IMDModule
          * as long as those interfaces are needed (probably the duration of an MD run).
          */
         static std::unique_ptr<RestraintMDModule>
-        create(std::shared_ptr<gmx::IRestraintPotential> restraint, unsigned long int site1, unsigned long int site2);
+        create(std::shared_ptr<gmx::IRestraintPotential> restraint, const std::vector<unsigned long int>& sites);
 
         /*!
          * \brief Implement IMDModule interface

--- a/src/gromacs/restraint/restraintpotential.cpp
+++ b/src/gromacs/restraint/restraintpotential.cpp
@@ -98,14 +98,4 @@ const struct pull_t *LegacyPuller::getRaw() const
 {
     return pullWorkPointer_;
 }
-
-void IRestraintPotential::update(gmx::Vector v,
-                                 gmx::Vector v0,
-                                 double t)
-{
-    // By default, an IRestraintPotential has a null updater.
-    (void)(v);
-    (void)(v0);
-    (void)(t);
-}
 } // end namespace gmx

--- a/src/gromacs/restraint/restraintpotential.h
+++ b/src/gromacs/restraint/restraintpotential.h
@@ -209,7 +209,10 @@ class IRestraintPotential
         // An update function to be called on the simulation master rank/thread periodically by the Restraint framework.
         virtual void update(gmx::Vector v,
                             gmx::Vector v0,
-                            double t);
+                            double t) { (void)v; (void)v0; (void)t; };
+        // We give the definition here because we don't want plugins to have to link against libgromacs right now.
+        // But once we've had plugin restraints wrap themselves in a Restraint template, we can
+        // set update = 0
 
         virtual /*!
          * \brief Find out what sites this restraint is configured to act on.

--- a/src/gromacs/restraint/restraintpotential.h
+++ b/src/gromacs/restraint/restraintpotential.h
@@ -218,7 +218,7 @@ class IRestraintPotential
          * \brief Find out what sites this restraint is configured to act on.
          * \return
          */
-        std::array<unsigned long int, 2> sites() const = 0;
+        std::vector<unsigned long int> sites() const = 0;
 };
 
 /*!

--- a/src/programs/mdrun/runner.cpp
+++ b/src/programs/mdrun/runner.cpp
@@ -1135,11 +1135,8 @@ int Mdrunner::mdrunner()
         auto puller = restraintManager_->getSpec();
         if (puller != nullptr)
         {
-            auto site1 = puller->sites()[0];
-            auto site2 = puller->sites()[1];
             auto module = ::gmx::RestraintMDModule::create(puller,
-                                                           site1,
-                                                           site2);
+                                                           puller->sites());
             mdModules.add(std::move(module));
         }
     }


### PR DESCRIPTION
In support of the ensemble reduce functionality and related features, minor updates are made to the restraints framework in the way restraint sites of interest are managed and to allow the restraint to provide call-backs. The call-back provision is very minimal and should be updated to allow specification of call-back intervals, among other things.