### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ This README.md file supplants the main README file to avoid merge conflicts whil
 
 # Installation
 
-Install as you would a regular copy of GROMACS.
+Install as you would a regular copy of GROMACS. The following example downloads the source into a directory named `gromacs`,
+creates a parallel (out-of-source) `build` directory, configures, builds, and installs. Use e.g. `make -j10 install` to build in parallel with 10 processes.
 
     $ git clone https://github.com/kassonlab/gromacs-gmxapi gromacs
     $ mkdir build
     $ cd build
-    $ cmake ../gromacs -DCMAKE_INSTALL_PREFIX=/path/to/where/i/want/gromacs
+    $ cmake ../gromacs -DCMAKE_INSTALL_PREFIX=/path/to/where/i/want/gromacs -DGMX_THREAD_MPI=ON -DGMX_GPU=OFF
     $ make install
 
-You may then either source the gmxrc file as usual or export the environment variable
+You may then either source the GMXRC file (as usual for GROMACS use) or export the environment variable
 `gmxapi_DIR=/path/to/where/i/want/gromacs` to help `gmxapi` clients such as the Python 
 package or your own CMake project to find
 what it needs to build against the gmxapi library.


### PR DESCRIPTION
Expand install instructions in response to user feedback.

It was suggested that `cmake ../gromacs` should have been `cmake ../`, which would be true if the `build` directory were created as a subdirectory of the GROMACS source, but there is no `cd gromacs` in the installation instructions. Some people may be accustomed to in-source builds and others to out-of-source builds (generally recommended), so I tried to emphasize that the docs are for the latter.