### PR TITLE
gmxapi-123 race condition when reusing contexts.

### DIFF
--- a/src/api/cpp/context.cpp
+++ b/src/api/cpp/context.cpp
@@ -13,6 +13,7 @@
 #include "programs/mdrun/runner.h"
 #include "gromacs/mdtypes/tpxstate.h"
 
+#include "gmxapi/exceptions.h"
 #include "gmxapi/gmxapi.h"
 #include "gmxapi/session.h"
 #include "gmxapi/status.h"
@@ -152,7 +153,10 @@ std::shared_ptr<Session> ContextImpl::launch(std::shared_ptr<ContextImpl> contex
 //            // If we can do something with the node, do it. If the spec is bad, error.
 //        }
     }
-    // \todo Make some note about the unsuccessful launch.
+    else
+    {
+        throw gmxapi::ProtocolError("Tried to launch a session while a session is still active.");
+    }
 
     if (session != nullptr)
     {

--- a/src/api/cpp/session.cpp
+++ b/src/api/cpp/session.cpp
@@ -85,6 +85,9 @@ Status SessionImpl::status() const noexcept
 
 std::unique_ptr<Status> SessionImpl::close()
 {
+    // When the Session is closed, we need to know that the MD output has been finalized, which currently requires
+    // gmx::MDrunner::~MDrunner() to be called.
+    runner_.reset();
     std::unique_ptr<Status> status{nullptr};
     status.swap(status_);
     assert(status_ == nullptr);

--- a/src/api/cpp/tests/test_md.cpp
+++ b/src/api/cpp/tests/test_md.cpp
@@ -4,31 +4,3 @@
 #include "gmxapi/status.h"
 #include "md-impl.h"
 #include "gromacs/utility/keyvaluetree.h"
-
-TEST(ApiModuleMD, Construction)
-{
-//    {   // Check default construction and destruction
-//        gmxapi::MDProxy proxy{};
-//    }
-    // Helper function should return a non-null unique_ptr
-//    ASSERT_TRUE(module.get() != nullptr);
-//    ASSERT_EQ(module->info(), "MDStatePlaceholder initialized with filename: \"topol.tpr\"\n");
-}
-
-TEST(ApiModuleMD, Build)
-{
-//    auto mdBuilder = gmxapi::MDProxy().builder();
-//    ASSERT_TRUE(mdBuilder != nullptr);
-//    auto md = mdBuilder->build();
-//    ASSERT_TRUE(md != nullptr);
-//    ASSERT_STREQ("Generic MDEngine object", md->info().c_str());
-}
-
-TEST(ApiModuleMD, Binding)
-{
-//    // Register MD with a runner
-//    auto module = gmxapi::mdFromTpr("topol.tpr");
-//    auto runner = MyRunner();
-//    module->bind(&runner);
-//    runner.run();
-}

--- a/src/api/cpp/tests/test_restraint.cpp
+++ b/src/api/cpp/tests/test_restraint.cpp
@@ -55,36 +55,5 @@ class SimpleApiModule : public gmxapi::MDModule
         }
 };
 
-// This testing is currently performed elsewhere.
-//TEST(ApiRestraint, MdAndNullPlugin)
-//{
-//
-//    {
-//        // \todo move slow validation tests to a separate testing suite.
-//        // Automate evaluation of the results of these test.
-//        std::string waterfile = "water.tpr";
-//        auto system = gmxapi::fromTprFile(waterfile);
-//
-//        auto module = std::make_shared<SimpleApiModule>();
-//        assert(module != nullptr);
-//        auto status = system->setRestraint(module);
-//        ASSERT_TRUE(status.success());
-//
-//        std::shared_ptr<gmxapi::Context> context = gmxapi::defaultContext();
-//
-//        auto session = system->launch(context);
-//        ASSERT_TRUE(session->isOpen());
-//
-//        ASSERT_NO_THROW(status = session->run());
-////        ASSERT_TRUE(module->force_called() > 0);
-////        ASSERT_NO_THROW(session->run(1000));
-//        ASSERT_TRUE(status.success());
-//        ASSERT_TRUE(session->isOpen());
-//        status = session->close();
-//        ASSERT_TRUE(status.success());
-//    }
-//
-//}
-
 
 } // end anonymous namespace


### PR DESCRIPTION
Resolve the bug aspect of https://github.com/kassonlab/gmxapi/issues/123

Make sure session close() results in verifiably finalized log file.
Make sure to propagate session closure down through API.

* Destroy the gmx::Mdrunner in Session::close().
* Flush fplog file descriptor before returning control to API after mdrunner().
* When fplog managed by runner is closed, set the FILE* pointer to null.