### PR TITLE
bug fix: Registered MD restraints persist between simulations

### DIFF
--- a/src/gromacs/restraint/harmonicrestraint.h
+++ b/src/gromacs/restraint/harmonicrestraint.h
@@ -19,7 +19,7 @@ namespace gmx
  * The potential is a functional of selected pair distances
  * evaluated
  */
-class RouxRestraint : public IRestraintPotential
+class HarmonicRestraint : public IRestraintPotential
 {
 
 };

--- a/src/gromacs/restraint/manager.cpp
+++ b/src/gromacs/restraint/manager.cpp
@@ -154,6 +154,15 @@ Manager::Manager() : impl_(gmx::compat::make_unique<ManagerImpl>()) {};
 
 Manager::~Manager() = default;
 
+void Manager::clear() noexcept
+{
+    auto new_impl = gmx::compat::make_unique<ManagerImpl>();
+    if (new_impl)
+    {
+        impl_.swap(new_impl);
+    }
+}
+
 std::shared_ptr<Manager> Manager::instance()
 {
     std::lock_guard<std::mutex> lock(initializationMutex_);
@@ -317,6 +326,11 @@ void Manager::addToSpec(std::shared_ptr<gmx::IRestraintPotential> puller,
 std::vector<std::shared_ptr<IRestraintPotential>> Manager::getSpec() const
 {
     return impl_->restraint_;
+}
+
+unsigned long Manager::countRestraints() noexcept
+{
+    return impl_->restraint_.size();
 }
 
 //void Manager::add(std::shared_ptr<gmx::IRestraintPotential> puller,

--- a/src/gromacs/restraint/manager.h
+++ b/src/gromacs/restraint/manager.h
@@ -80,6 +80,21 @@ class Manager final
         Manager(Manager&&) = delete;
         Manager& operator=(Manager&&) = delete;
 
+        /*!
+         * \brief Clear registered restraints and reset the manager.
+         */
+        void clear() noexcept ;
+
+        /*!
+         * \brief Get the number of currently managed restraints.
+         *
+         * \return number of restraints.
+         *
+         * \internal
+         * Only considers the IRestraintPotential objects
+         */
+        unsigned long countRestraints() noexcept;
+
         /*! \brief Obtain the ability to create a restraint MDModule
          *
          * Though the name is reminiscent of the evolving idea of a work specification, the
@@ -91,6 +106,11 @@ class Manager final
         void addToSpec(std::shared_ptr<gmx::IRestraintPotential> puller,
                        std::string name);
 
+        /*!
+         * \brief Get a copy of the current set of restraints to be applied.
+         *
+         * \return a copy of the list of restraint potentials.
+         */
         std::vector<std::shared_ptr<IRestraintPotential>> getSpec() const;
 
         void add(std::shared_ptr<LegacyPuller> puller, std::string name);

--- a/src/gromacs/restraint/tests/manager.cpp
+++ b/src/gromacs/restraint/tests/manager.cpp
@@ -6,11 +6,51 @@
 namespace
 {
 
+class DummyRestraint: public gmx::IRestraintPotential
+{
+    public:
+        ~DummyRestraint() override = default;
+
+        gmx::PotentialPointData evaluate(gmx::Vector r1,
+                                         gmx::Vector r2,
+                                         double t) override
+        {
+            return {};
+        }
+
+        void update(gmx::Vector v,
+                    gmx::Vector v0,
+                    double t) override
+        { (void)v; (void)v0; (void)t; }
+
+        std::vector<unsigned long> sites() const override
+        {
+            return std::vector<unsigned long>();
+        }
+
+        void bindSession(gmxapi::Session *session) override
+        {
+            (void)session;
+        }
+};
+
 TEST(RestraintManager, singleton)
 {
-    ASSERT_TRUE(true);
     auto managerInstance = gmx::restraint::Manager::instance();
     ASSERT_TRUE(managerInstance.get() != nullptr);
+}
+
+TEST(RestraintManager, restraintList)
+{
+    auto managerInstance = gmx::restraint::Manager::instance();
+    managerInstance->addToSpec(std::make_shared<DummyRestraint>(), "a");
+    managerInstance->addToSpec(std::make_shared<DummyRestraint>(), "b");
+    ASSERT_EQ(managerInstance->countRestraints(), 2);
+    managerInstance->clear();
+    ASSERT_EQ(managerInstance->countRestraints(), 0);
+    managerInstance->addToSpec(std::make_shared<DummyRestraint>(), "c");
+    managerInstance->addToSpec(std::make_shared<DummyRestraint>(), "d");
+    ASSERT_EQ(managerInstance->countRestraints(), 2);
 }
 
 }

--- a/src/programs/mdrun/runner.cpp
+++ b/src/programs/mdrun/runner.cpp
@@ -1788,7 +1788,10 @@ int Mdrunner::mdrunner()
 
 Mdrunner::Mdrunner()
 {
+    // Assume ownership of the Manager singleton
     restraintManager_ = ::gmx::restraint::Manager::instance();
+    restraintManager_->clear();
+    assert(restraintManager_->countRestraints() == 0);
 
     cr = init_commrec();
     // oenv initialized by parse_commond_args


### PR DESCRIPTION
Even creating a new Context with each iteration, and without any indication from higher-level interfaces, MDRunners quietly accumulated restraints registered since libgromacs was first loaded in the process. When gmx::restraint::Manager was extended to manage multiple restraints, the automatic reset of the previous restraint was lost. This PR adds a `clear()` method, a `countRestraints` method for checking, unit tests for the intended behavior, and an explicit reset of the restraint manager when an MDRunner is created.