### PR TITLE
Try to let ccache be more specific.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ sudo: false
 cache:
   apt: true
   directories:
-    - $HOME/.ccache
-    - $HOME/.ccache_mpi
+    - $HOME/.ccache_gromacs
 # It may be important to separately store the caches for different build configurations and set CCACHE_DIR
 os: linux
 
@@ -40,7 +39,7 @@ matrix:
             - liblapack-dev
             - libxml2-dev
       env:
-        - MATRIX_EVAL="GMX_DOUBLE=OFF && GMX_MPI=OFF && GMX_THREAD_MPI=ON && CC=`which gcc-6` && CXX=`which g++-6` && export CCACHE_DIR=$HOME/.ccache"
+        - MATRIX_EVAL="GMX_DOUBLE=OFF && GMX_MPI=OFF && GMX_THREAD_MPI=ON && CC=`which gcc-6` && CXX=`which g++-6` && export CCACHE_DIR=$HOME/.ccache_gromacs"
     # MPICH with gcc-4.8.5
     # It seems we may have to build MPI ourselves if we want to use any non-default compiler?
     - compiler: gcc
@@ -63,7 +62,7 @@ matrix:
             - libxml2-dev
             - mpich
       env:
-        - MATRIX_EVAL="GMX_DOUBLE=OFF && GMX_MPI=ON && GMX_THREAD_MPI=OFF && CC=`which mpicc` && CXX=`which mpicxx` && export CCACHE_DIR=$HOME/.ccache_mpi"
+        - MATRIX_EVAL="GMX_DOUBLE=OFF && GMX_MPI=ON && GMX_THREAD_MPI=OFF && CC=`which mpicc` && CXX=`which mpicxx` && export CCACHE_DIR=$HOME/.ccache_gromacs"
 
 before_install:
   - uname -a
@@ -71,20 +70,22 @@ before_install:
   - dpkg-query -L doxygen
   - eval "${MATRIX_EVAL}"
   - export CCACHE_COMPILERCHECK=content
-  - export CCACHE_SLOPPINESS="file_macro,include_file_ctime,include_file_mtime,no_system_headers,pch_defines,time_macros"
   - ${CC} --version
   - ${CXX} --version
   - ccache -s
 
 install:
   - pwd
-  - mkdir build && pushd build && cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DBUILD_TESTING=ON -DGMX_DOUBLE=$GMX_DOUBLE -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI .. && make -j1
-  - make check
+  - mkdir build
+  - pushd build
+  - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DBUILD_TESTING=ON -DGMX_DOUBLE=$GMX_DOUBLE -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI ..
+  - sleep 2 # give a couple of seconds for generated source files to be clearly "in the past"
+  - make -j2 && make -j2 tests
   - popd
   - ccache -s
 
 script:
   - pwd
   - pushd build
-  - make check
+  - make -j2 check
   - popd


### PR DESCRIPTION
Sloppy ccache could lead to sporadic errors. Try to find a minimal set
of "sloppiness" settings that keep the caching effective.

This PR will be built several times. It will first check its own PR cache and then the devel branch cache. The goal of this PR is to eliminate CCACHE_SLOPPINESS settings that aren't helping us and can therefore be removed from .travis.yml. If there are remaining sloppiness settings that speed up builds, but are dangerous, they will be easier to diagnose afterwards.