### PR TITLE
Reset the signal counter when restraints are added.

### DIFF
--- a/src/api/cpp/mdsignals.cpp
+++ b/src/api/cpp/mdsignals.cpp
@@ -48,6 +48,7 @@ class StopSignal : public Signal::SignalImpl
         StopSignal(gmx::Mdrunner* runner, unsigned int numParticipants) : StopSignal(runner)
         {
             StopSignal::numParticipants_.store(numParticipants);
+            StopSignal::numCalls_.store(0);
         }
 
         void call() override


### PR DESCRIPTION
The signaling mechanism for restraint plugins to issue a stop signal to the MD simulation was not reset between simulations. As a quick fix, this PR sets the call-counter back to zero when restraints are added and subscribed to the signaler.