### PR TITLE
Beginnings of SessionResources.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install:
   - pwd
   - mkdir build
   - pushd build
-  - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DBUILD_TESTING=ON -DGMX_DOUBLE=$GMX_DOUBLE -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI ..
+  - cmake -DGMX_BUILD_HELP=OFF -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DBUILD_TESTING=ON -DGMX_DOUBLE=$GMX_DOUBLE -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI ..
   - sleep 2 # give a couple of seconds for generated source files to be clearly "in the past"
   - make -j2 && make -j2 tests
   - popd

--- a/src/api/cpp/CMakeLists.txt
+++ b/src/api/cpp/CMakeLists.txt
@@ -27,6 +27,7 @@ configure_file(gmxapi/md/mdsignals.h gmxapi/md)
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gmxapi/session)
 configure_file(gmxapi/session/outputstream.h gmxapi/session)
+configure_file(gmxapi/session/resources.h gmxapi/session)
 #configure_file(gmxapi/session/input.h gmxapi/session)
 
 # Add to install target: copy the public API headers from the source directory
@@ -77,9 +78,11 @@ target_sources(
         md.cpp
         mdmodule.cpp
         mdsignals.cpp
+        mdsignals-impl.h
         outputstream.cpp
         session-impl.h
         session.cpp
+        sessionresources-impl.h
         status.cpp
         system.cpp
         system-impl.h

--- a/src/api/cpp/gmxapi/context.h
+++ b/src/api/cpp/gmxapi/context.h
@@ -101,7 +101,9 @@ class Context
 
     private:
         /*!
-         * \brief Private implementation may be shared by several interfaces.
+         * \brief Private implementation
+         *
+         * May be shared by several interfaces. Various objects need to extend the life of the Context.
          */
         std::shared_ptr<ContextImpl> impl_;
 };

--- a/src/api/cpp/gmxapi/exceptions.h
+++ b/src/api/cpp/gmxapi/exceptions.h
@@ -83,6 +83,14 @@ class BasicException : public Exception
             what_ = message;
         }
 
+        /*!
+         * \brief Get message.
+         *
+         * \return pointer to C string.
+         *
+         * It is the responsibility of the caller to keep the Exception object alive while the char
+         * pointer is in use.
+         */
         const char* what() const noexcept override
         {
             return what_.c_str();

--- a/src/api/cpp/gmxapi/gmxapi.h
+++ b/src/api/cpp/gmxapi/gmxapi.h
@@ -307,6 +307,50 @@ class MDHolder {
          * It is used when setting up and then launching the simulation.
          *
          * \param spec references a container with interfaces for client and library APIs
+         *
+         * Example:
+         *
+         *     # With `system` as a gmxapi::System object
+         *     auto spec = system->getSpec();
+         *     auto holder = gmx::compat::make_unique<gmxapi::MDHolder>(spec);
+         *
+         * A PyCapsule object with the name given by gmxapi::MDHolder_Name is assumed to
+         * contain a pointer to an MDHolder and to have an appropriate deleter attached.
+         *
+         * Example:
+         *
+         *     auto deleter = [](PyObject *o) {
+         *         if (PyCapsule_IsValid(o, gmxapi::MDHolder_Name))
+         *         {
+         *             auto holder_ptr = (gmxapi::MDHolder *) PyCapsule_GetPointer(o, gmxapi::MDHolder_Name);
+         *             delete holder_ptr;
+         *         };
+         *     };
+         *     # With pybind11 PyCapsule bindings:
+         *     auto capsule = py::capsule(holder,
+         *                                gmxapi::MDHolder_Name,
+         *                                deleter);
+         *
+         * The gmxapi Python package gives modules a chance to associate themselves with a
+         * gmxapi::System object by passing such a PyCapsule to its `bind` method, if implemented.
+         *
+         * Such a bind method could be implemented as follows. Assume object.ptr() returns a
+         * `PyObject*`
+         *
+         * Example:
+         *
+         *    PyObject* capsule = object.ptr();
+         *    if (PyCapsule_IsValid(capsule, gmxapi::MDHolder::api_name))
+         *    {
+         *        auto holder = static_cast<gmxapi::MDHolder*>(PyCapsule_GetPointer(capsule,
+         *            gmxapi::MDHolder::api_name));
+         *        auto workSpec = holder->getSpec();
+         *        workSpec->addModule(module);
+         *    }
+         *    else
+         *    {
+         *        throw gmxapi::ProtocolError("bind method requires a python capsule as input");
+         *    }
          */
         explicit MDHolder(std::shared_ptr<MDWorkSpec> spec);
 

--- a/src/api/cpp/gmxapi/md/mdsignals.h
+++ b/src/api/cpp/gmxapi/md/mdsignals.h
@@ -2,21 +2,35 @@
 // Created by Eric Irrgang on 5/18/18.
 //
 
-/* WARNING
- * This whole file is not intended to make it into a public release and is not part of the gmxapi API. It is for
- * prototyping only. Please don't let it slip into a release without serious design considerations.
- */
-
 #ifndef GMXAPI_MDSIGNALS_H
 #define GMXAPI_MDSIGNALS_H
+
+/*! \internal
+ * \file
+ * \brief Temporary infrastructure for signalling MD simulations.
+ *
+ * These interfaces are not considered to be part of the gmxapi spec, but will exist in 0.0.6 and
+ * possibly 0.0.7 until more abstract data flow is available to MD plugin developers, at which point
+ * any remaining functionality here will be moved to private implementation details.
+ *
+ * \ingroup gmxapi_md
+ */
 
 #include <memory>
 
 namespace gmxapi {
 
+/*!
+ * \brief Internal details of gmxapi MD functionality
+ */
 namespace md
 {
 
+/*!
+ * \brief Symbolic signal slots for MD signalling.
+ *
+ * \see getMdrunnerSignal()
+ */
 enum class signals {
         STOP
 };
@@ -50,6 +64,7 @@ class Signal
  * \brief Get a function object that issues a signal to the currently active MD runner.
  *
  * \param resources pointer to the active Session resources.
+ * \param signal type of signal the client would like to issue.
  * \return Callable function object handle
  *
  * \throws gmxapi::NotImplementedError for unknown values of signal.

--- a/src/api/cpp/gmxapi/md/mdsignals.h
+++ b/src/api/cpp/gmxapi/md/mdsignals.h
@@ -24,7 +24,7 @@ enum class signals {
 } // end namespace md
 
 
-class Session;  // defined in gmxapi/session.h
+class SessionResources;  // reference gmxapi/session/resources.h
 
 /*!
  * \brief Proxy for signalling function objects.
@@ -36,8 +36,8 @@ class Signal
     public:
         class SignalImpl;
         explicit Signal(std::unique_ptr<SignalImpl>&& signal);
-        Signal(Signal&& signal);
-        Signal& operator=(Signal&& signal);
+        Signal(Signal&& signal) noexcept ;
+        Signal& operator=(Signal&& signal) noexcept ;
         ~Signal();
 
         void operator()();
@@ -49,10 +49,13 @@ class Signal
 /*!
  * \brief Get a function object that issues a signal to the currently active MD runner.
  *
- * \param session pointer to the active Session.
+ * \param resources pointer to the active Session resources.
  * \return Callable function object handle
+ *
+ * \throws gmxapi::NotImplementedError for unknown values of signal.
  */
-Signal getMdrunnerSignal(Session* session, md::signals signal);
+Signal getMdrunnerSignal(SessionResources *resources,
+                         md::signals signal);
 
 } // end namespace md
 

--- a/src/api/cpp/gmxapi/session.h
+++ b/src/api/cpp/gmxapi/session.h
@@ -119,14 +119,19 @@ class Session
         SessionImpl* getRaw() const noexcept;
 
     private:
-        friend
-        Status setSessionRestraint(Session* session,
-                                   std::shared_ptr<MDModule> module);
-
-
         /// \brief opaque pointer to implementation
         std::unique_ptr<SessionImpl> impl_;
 };
+
+/*!
+ * \brief Set a uniquely identifiable restraint instance on the MD simulator.
+ *
+ * \param session
+ * \param module
+ * \return
+ */
+Status setSessionRestraint(Session *session,
+                           std::shared_ptr<gmxapi::MDModule> module);
 
 /*!
  * \brief Launch a workflow in the provided execution context.

--- a/src/api/cpp/gmxapi/session.h
+++ b/src/api/cpp/gmxapi/session.h
@@ -126,9 +126,9 @@ class Session
 /*!
  * \brief Set a uniquely identifiable restraint instance on the MD simulator.
  *
- * \param session
- * \param module
- * \return
+ * \param session Session with an MD runner to attach a restraint to.
+ * \param module restraint module.
+ * \return success if restraint was attached successfully, else failure.
  */
 Status setSessionRestraint(Session *session,
                            std::shared_ptr<gmxapi::MDModule> module);

--- a/src/api/cpp/gmxapi/session/resources.h
+++ b/src/api/cpp/gmxapi/session/resources.h
@@ -1,0 +1,28 @@
+//
+// Created by Eric Irrgang on 7/10/18.
+//
+
+#ifndef GMXAPI_SESSION_RESOURCES_H
+#define GMXAPI_SESSION_RESOURCES_H
+
+/*! \file
+ * \brief Define interface to Session Resources for running gmxapi operations.
+ */
+
+namespace gmxapi {
+
+/*!
+ * \brief Handle to Session-provided resources.
+ *
+ * Session handle for workflow elements requiring resources provided through the Session.
+ *
+ * Provided during launch through gmx::IRestraintPotential::bindSession()
+ *
+ * No public interface yet. Use accompanying free functions.
+ * \see gmxapi::getMdrunnerSignal()
+ */
+class SessionResources;
+
+} // end namespace gmxapi
+
+#endif //GMXAPI_SESSION_RESOURCES_H

--- a/src/api/cpp/gmxapi/system.h
+++ b/src/api/cpp/gmxapi/system.h
@@ -17,12 +17,23 @@ class Session;
 
 /// Container for molecular model and simulation parameters.
 /*!
- * \cond
- * A system instance is sort of a container of builders, and a Context is sort of a factory. together they allow a simulation to be constructed and initialized with the appropriate implementations of runner, integrator, and data objects.
+ * \brief Deprecated: A wrapper for gmx::Mdrunner
  *
- * Ultimately, the system needs to pass serialized data sufficient to reconstruct
- * itself as part of the workflow it contains when the work is launched.
- * \endcond
+ * It was not intended to end up as such, but gmxapi::System has ended up as basically a
+ * wrapper for the gmx::Mdrunner simulator object. As it is, this class does not fit the
+ * current gmxapi paradigm and will be removed, reworked, or renamed soon.
+ *
+ * # Protocol
+ *
+ * As of gmxapi 0.0.6, a simulation is configured and launched as follows.
+ *
+ * 1. Caller gets a System handle with gmxapi::fromTprFile().
+ * 2. Caller optionally attaches additional MD Modules with getSpec()->addModule(std::shared_ptr<gmxapi::MDModule> module). See gmxapi::MDHolder
+ * 3. Caller gets a runnable object by passing a Context to System::launch()
+ *
+ * During launch() configured gmxapi::MDModules are attached to the simulator, which is
+ * then run by calling run() on the object returned by launch().
+ *
  * \ingroup gmxapi
  */
 class System final
@@ -64,7 +75,15 @@ class System final
 
         Status setRestraint(std::shared_ptr<gmxapi::MDModule> module);
 
-        // \todo This is used in gmxpy but not tested here.
+        /*!
+         * \brief Borrow shared ownership of the System's container of associated modules.
+         *
+         * Used with gmxapi::MDHolder to add MD Modules to the simulation to be run.
+         *
+         * \return handle to be passed to gmxapi::MDHolder
+         *
+         * \todo This is used in gmxpy but not tested here.
+         */
         std::shared_ptr<MDWorkSpec> getSpec();
 
         /*!
@@ -73,18 +92,45 @@ class System final
          * \return Ownership of a ready-to-run workflow or nullptr if there were errors.
          *
          * If errors occur, they will be stored in the context object. If run without
-         * and argument, launch() uses the current context of the System object. If a
+         * an argument, launch() uses the current context of the System object. If a
          * context argument is given, the system and its configured workflow are
          * translated to the provided context and launched.
          *
          * \param context (optional) execution context in which to launch.
          *
-         * The Session object does not "own" the Context, but must be able to extend the lifetime of the Context in
+         * \note The Session object does not "own" the Context, but must be able to extend the lifetime of the Context in
          * which it is running.
          *
          * \todo Policy: does System then track the (potentially remote) context or should
          * it be considered to have "forked", and the new session object retrieved from
          * the session handle if needed.
+         *
+         * \cond internal
+         * # Protocol
+         *
+         * The current implementation of System::launch() performs the following actions.
+         *
+         * When launch() is called, a new gmxapi::Session is created by passing a gmxapi::Workflow to context->launch(). The Workflow basically just contains the TPR filename.
+         * 1. A new Mdrunner is created from the information in the gmxapi::Workflow
+         * 2. A new Session is created using the ContextImpl and the runner
+         *
+         * Then, for each module available through getSpec()->getModules(), the session and module
+         * are passed to gmxapi::setSessionRestraint().
+         * 1. A gmx::IRestraintPotential is retrieved from the module.
+         * 2. A unique, named SessionResources is created for the module and attached to the SessionImpl.
+         * 3. The SessionResources is passed to IRestraintPotential::bindSession(). Currently, the only thing
+         *    the restraint could do at this point is to save a copy of the pointer and later pass it to
+         *    gmxapi::getMdrunnerSignal().
+         * 4. The restraint is passed to gmx::Mdrunner::addPullPotential(), which adds the restraint to
+         *    the global gmx::restraint::Manager, which then needs to be `clear()`ed after the runner completes.
+         *
+         * Shared ownership of the Session is returned to the caller of launch().
+         *
+         * \todo gmx::restraint::Manager should not be a singleton.
+         * It currently performs a similar role to the gmxapi::System::spec_ member and should be passed to
+         * the runner, but we don't have a way to do that right now.
+         *
+         * \endcond
          *
          * \{
          */

--- a/src/api/cpp/gmxapi/system.h
+++ b/src/api/cpp/gmxapi/system.h
@@ -118,11 +118,12 @@ class System final
          * are passed to gmxapi::setSessionRestraint().
          * 1. A gmx::IRestraintPotential is retrieved from the module.
          * 2. A unique, named SessionResources is created for the module and attached to the SessionImpl.
-         * 3. The SessionResources is passed to IRestraintPotential::bindSession(). Currently, the only thing
-         *    the restraint could do at this point is to save a copy of the pointer and later pass it to
-         *    gmxapi::getMdrunnerSignal().
-         * 4. The restraint is passed to gmx::Mdrunner::addPullPotential(), which adds the restraint to
-         *    the global gmx::restraint::Manager, which then needs to be `clear()`ed after the runner completes.
+         *     1. The module is added as a signaller to the session SignalManager with getSignalManager()->addSignaller(module->name())
+         *     2. The SessionResources is passed to IRestraintPotential::bindSession(). Currently, the only thing
+         *        the restraint could do at this point is to save a copy of the pointer and later pass it to
+         *        gmxapi::getMdrunnerSignal().
+         *     3. The restraint is passed to gmx::Mdrunner::addPullPotential(), which adds the restraint to
+         *        the global gmx::restraint::Manager, which then needs to be `clear()`ed after the runner completes.
          *
          * Shared ownership of the Session is returned to the caller of launch().
          *

--- a/src/api/cpp/mdsignals-impl.h
+++ b/src/api/cpp/mdsignals-impl.h
@@ -1,0 +1,89 @@
+//
+// Created by Eric Irrgang on 7/10/18.
+//
+
+#ifndef GMXAPI_MDSIGNALS_IMPL_H
+#define GMXAPI_MDSIGNALS_IMPL_H
+
+#include "gmxapi/md/mdsignals.h"
+
+#include <atomic>
+
+#include "gromacs/compat/make_unique.h"
+#include "gromacs/mdlib/simulationsignal.h"
+#include "programs/mdrun/runner.h"
+
+#include "gmxapi/session.h"
+
+#include "session-impl.h"
+
+namespace gmxapi {
+
+
+class Signal::SignalImpl
+{
+    public:
+        virtual void call() = 0;
+};
+
+class StopSignal : public Signal::SignalImpl
+{
+    public:
+        explicit StopSignal(gmx::Mdrunner* runner);
+
+        void call() override;
+
+    private:
+        gmx::Mdrunner* runner_;
+};
+
+/*!
+ * \brief Manage signal paths exposed through session resources to gmxapi operations.
+ *
+ * Manages signals for a single gmx::Mdrunner. Currently only supports a stop signal that
+ * is required to be issued by all registered possible issuers before the signal is sent to
+ * the associated runner. This is not what we want in the long run. This class should handle
+ * signal inputs to operations that take signals as input (like Mdrunner) and should allow
+ * multiple subscribers. For additional signal processing, such as boolean operations,
+ * additional operations should be inserted in a chain.
+ */
+class SignalManager
+{
+    public:
+        explicit SignalManager(gmx::Mdrunner* runner);
+        ~SignalManager();
+
+        /*!
+         * \brief Add a name to the list of operations that will be using this signal.
+         */
+        void addSignaller(std::string name);
+
+        /*!
+         * \brief Allow a registered signaller to retrieve a functor.
+         *
+         * \param name Registered signal issuer.
+         * \return Generic Signal object.
+         *
+         * \throws gmxapi::ProtocolError if named signaller was not previously registered.
+         */
+        Signal getSignal(std::string name,
+                         md::signals signal);
+
+        /*!
+         * \brief A member class that can access SignalManager's private members.
+         */
+        class LogicalAND;
+
+    private:
+        gmx::Mdrunner* runner_;
+        /*!
+         * \brief Track whether the signal has been issued by each registrant.
+         */
+        std::map<std::string, std::atomic_bool> called_;
+};
+
+
+
+} //end namespace gmxapi
+
+#endif //GMXAPI_MDSIGNALS_IMPL_H

--- a/src/api/cpp/mdsignals-impl.h
+++ b/src/api/cpp/mdsignals-impl.h
@@ -46,6 +46,9 @@ class StopSignal : public Signal::SignalImpl
  * signal inputs to operations that take signals as input (like Mdrunner) and should allow
  * multiple subscribers. For additional signal processing, such as boolean operations,
  * additional operations should be inserted in a chain.
+ *
+ * A SignalManager should be created for each consumer (each gmx::Mdrunner) in a Session.
+ * This occurs in the SessionImpl::create() function.
  */
 class SignalManager
 {

--- a/src/api/cpp/mdsignals-impl.h
+++ b/src/api/cpp/mdsignals-impl.h
@@ -5,6 +5,12 @@
 #ifndef GMXAPI_MDSIGNALS_IMPL_H
 #define GMXAPI_MDSIGNALS_IMPL_H
 
+/*! \file
+ * \brief Implementation details for gmxapi::Signal and related gmxapi::md infrastructure.
+ *
+ * \ingroup gmxapi_md
+ */
+
 #include "gmxapi/md/mdsignals.h"
 
 #include <atomic>
@@ -20,20 +26,48 @@
 namespace gmxapi {
 
 
+/*!
+ * \brief The Signal Implementation interface.
+ *
+ * A SignalImpl concrete class must implement a `call()` method that issues the signal.
+ */
 class Signal::SignalImpl
 {
     public:
         virtual void call() = 0;
 };
 
+/*!
+ * \brief Signal implementation for MD simulation stop signals.
+ *
+ * Provides a call() operator that sets the stop condition for the MD simulation.
+ *
+ * Client code is not expected to create objects of this type directly, but to retrieve
+ * one, wrapped in a gmxapi::Signal for immediate use, from a SignalManager with SignalManager::getSignal()
+ *
+ * It is the responsibility of the client code to make sure that the address of the Mdrunner
+ * remains valid for the lifetime of this object.
+ */
 class StopSignal : public Signal::SignalImpl
 {
     public:
+        /*!
+         * \brief Create short-lived signal implementation.
+         *
+         * \param runner non-owning handle
+         *
+         * The object is constructed with a handle to the runner associated with the SignalManager and
+         * owned by the owner of the SignalManager.
+         */
         explicit StopSignal(gmx::Mdrunner* runner);
 
+        /*!
+         * \brief Set a stop condition for the attached runner.
+         */
         void call() override;
 
     private:
+        /// non-owning handle to a runner owned by the owner of the SignalManager.
         gmx::Mdrunner* runner_;
 };
 
@@ -47,8 +81,15 @@ class StopSignal : public Signal::SignalImpl
  * multiple subscribers. For additional signal processing, such as boolean operations,
  * additional operations should be inserted in a chain.
  *
+ * SignalManager objects are created during Session launch and are owned exclusively by session
+ * implementation objects. If Session::isOpen() is true, the SignalManager should still be valid,
+ * but the intended use case is for SignalManager handles to be retrieved immediately before use
+ * by implementation code within the library with SessionImpl::getSignalManager().
+ *
  * A SignalManager should be created for each consumer (each gmx::Mdrunner) in a Session.
  * This occurs in the SessionImpl::create() function.
+ *
+ * \ingroup gmxapi_md
  */
 class SignalManager
 {
@@ -65,6 +106,7 @@ class SignalManager
          * \brief Allow a registered signaller to retrieve a functor.
          *
          * \param name Registered signal issuer.
+         * \param signal type of signal the client would like to issue.
          * \return Generic Signal object.
          *
          * \throws gmxapi::ProtocolError if named signaller was not previously registered.
@@ -78,6 +120,7 @@ class SignalManager
         class LogicalAND;
 
     private:
+        /// Non-owning handle to the associated runner.
         gmx::Mdrunner* runner_;
         /*!
          * \brief Track whether the signal has been issued by each registrant.

--- a/src/api/cpp/mdsignals.cpp
+++ b/src/api/cpp/mdsignals.cpp
@@ -5,24 +5,22 @@
 #include "gmxapi/md/mdsignals.h"
 
 #include <atomic>
+#include <algorithm>
+#include "gmxapi/exceptions.h"
 
 #include "gromacs/compat/make_unique.h"
 #include "gromacs/mdlib/simulationsignal.h"
 #include "programs/mdrun/runner.h"
 
 #include "gmxapi/session.h"
-
-#include "session-impl.h"
+#include "sessionresources-impl.h"
+#include "mdsignals-impl.h"
 
 namespace gmxapi {
 
-class Signal::SignalImpl
-{
-    public:
-        virtual void call() = 0;
 
-
-};
+Signal::Signal(Signal &&signal) noexcept = default;
+Signal &Signal::operator=(Signal &&signal) noexcept = default;
 
 Signal::Signal(std::unique_ptr<gmxapi::Signal::SignalImpl>&& impl) :
     impl_{std::move(impl)}
@@ -36,69 +34,82 @@ void Signal::operator()()
     impl_->call();
 }
 
-Signal::Signal(Signal &&signal) = default;
+StopSignal::StopSignal(gmx::Mdrunner *runner) : runner_{runner}
+{}
 
-Signal &Signal::operator=(Signal &&signal) = default;
+void StopSignal::call()
+{
+    auto signals = runner_->signals();
+    // sig > 0 stops at next NS step. sig < 0 stops at next step.
+    signals->at(eglsSTOPCOND).sig = -1;
+}
 
-class StopSignal : public Signal::SignalImpl
+void SignalManager::addSignaller(std::string name)
+{
+    called_[name].store(false);
+}
+
+class SignalManager::LogicalAND : public Signal::SignalImpl
 {
     public:
-        explicit StopSignal(gmx::Mdrunner* runner) : runner_{runner} {};
-
-        StopSignal(gmx::Mdrunner* runner, unsigned int numParticipants) : StopSignal(runner)
-        {
-            StopSignal::numParticipants_.store(numParticipants);
-            StopSignal::numCalls_.store(0);
-        }
+        LogicalAND(SignalManager* manager, std::string name) :
+            name_{std::move(name)},
+            manager_{manager}
+        {}
 
         void call() override
         {
-            unsigned int n{++StopSignal::numCalls_};
-            if (n >= StopSignal::numParticipants_.load())
-            {   
-                auto signals = runner_->signals();
-                // sig > 0 stops at next NS step. sig < 0 stops at next step.
-                signals->at(eglsSTOPCOND).sig = -1;
+            auto& callCounter = manager_->called_.at(name_);
+            callCounter.store(true);
+            using pairType = typename decltype(manager_->called_)::value_type;
+            if (std::all_of(manager_->called_.cbegin(),
+                            manager_->called_.cend(),
+                            [](const pairType& p){ return p.second.load(); }))
+            {
+                StopSignal(manager_->runner_).call();
             }
         }
 
     private:
-        gmx::Mdrunner* runner_;
-
-        // Number of participants in this signal
-        static std::atomic<unsigned int> numParticipants_;
-
-        // Number of times the signal has been called.
-        static std::atomic<unsigned int> numCalls_;
+        const std::string name_;
+        SignalManager* manager_;
 };
 
-std::atomic<unsigned int> StopSignal::numParticipants_{0};
-std::atomic<unsigned int> StopSignal::numCalls_{0};
+Signal SignalManager::getSignal(std::string name,
+                                md::signals signal)
+{
+    if (called_.find(name) == called_.end())
+    {
+        std::string message = name + " is not registered for this signal.";
+        throw gmxapi::ProtocolError(std::move(message));
+    }
 
-Signal getMdrunnerSignal(Session* session, md::signals signal)
+    if(signal != md::signals::STOP)
+    {
+        throw gmxapi::NotImplementedError("This signaller only handles stop signals.");
+    }
+
+    auto signalImpl = gmx::compat::make_unique<LogicalAND>(this, name);
+    Signal functor{std::move(signalImpl)};
+    return functor;
+}
+
+Signal getMdrunnerSignal(SessionResources *resources,
+                         md::signals signal)
 {
 //// while there is only one choice...
 //    if (signal == md::signals::STOP)
 //    {
-    assert(signal == md::signals::STOP);
-    assert(session);
+    if(signal != md::signals::STOP)
+    {
+        throw gmxapi::NotImplementedError("This signaller only handles stop signals.");
+    };
 
-    auto impl = session->getRaw();
-    assert(impl);
+    assert(resources);
 
-    auto runner = impl->getRunner();
-    assert(runner);
+    auto signaller = resources->getMdrunnerSignal(signal);
 
- //   std::unique_ptr<Signal::SignalImpl> signalImpl = gmx::compat::make_unique<StopSignal>(runner);
-    std::unique_ptr<Signal::SignalImpl> signalImpl = gmx::compat::make_unique<StopSignal>(runner, impl->numRestraints);
-
-    Signal functor{std::move(signalImpl)};
-
-    return functor;
-//    }
-//    else
-//    {
-//    }
+    return signaller;
 }
 
 } // end namespace gmxapi

--- a/src/api/cpp/mdsignals.cpp
+++ b/src/api/cpp/mdsignals.cpp
@@ -2,6 +2,12 @@
 // Created by Eric Irrgang on 5/18/18.
 //
 
+/*! \file
+ * \brief Implementation details for MD signalling support.
+ *
+ * \ingroup gmxapi_md
+ */
+
 #include "gmxapi/md/mdsignals.h"
 
 #include <atomic>
@@ -49,6 +55,25 @@ void SignalManager::addSignaller(std::string name)
     called_[name].store(false);
 }
 
+/*!
+ * Implement the SignalImpl interface to provide a logical AND for managed MD signals.
+ *
+ * Tracks whether each registered input has issued a signal to this operation. When the
+ * final registered input issues `call()`, the LogicalAND issues `call()` on the output
+ * signal path.
+ *
+ * State is managed by the parent SignalManager. Client code should get a short-lived handle
+ * to a Signal wrapping this implementation object by calling SignalManager::getSignal()
+ * with the unique workflow operation name for the block of client code and a gmxapi::md::signals::STOP
+ * signal argument.
+ *
+ * Currently explicitly supports the MD stop signal only.
+ *
+ * Version gmxapi 0.0.6:  Also, all registered restraints
+ * are automatically in the set of ANDed inputs.
+ *
+ * \ingroup gmxapi_md
+ */
 class SignalManager::LogicalAND : public Signal::SignalImpl
 {
     public:

--- a/src/api/cpp/session-impl.h
+++ b/src/api/cpp/session-impl.h
@@ -167,6 +167,8 @@ class SessionImpl
         std::unique_ptr<gmx::Mdrunner> runner_;
 
         std::unique_ptr<SignalManager> signal_;
+
+        std::map<std::string, std::weak_ptr<gmx::IRestraintPotential>> restraints_;
 };
 
 } //end namespace gmxapi

--- a/src/api/cpp/session-impl.h
+++ b/src/api/cpp/session-impl.h
@@ -73,6 +73,17 @@ class SessionImpl
          */
         Status run() noexcept;
 
+        /*!
+         * \brief Create a new implementation object and transfer ownership.
+         *
+         * \param context Shared ownership of a Context implementation instance.
+         * \param runner MD simulation operation to take ownership of.
+         * \return Ownership of new instance.
+         *
+         * A gmxapi::SignalManager is created with lifetime tied to the SessionImpl. The SignalManager
+         * is created with a non-owning pointer to runner. Signal issuers are registered with the
+         * manager when createResources() is called.
+         */
         static std::unique_ptr<SessionImpl> create(std::shared_ptr<ContextImpl> context,
                                                    std::unique_ptr<gmx::Mdrunner> runner);
 
@@ -96,6 +107,18 @@ class SessionImpl
          */
         gmxapi::SessionResources* getResources(const std::string& name) const noexcept;
 
+        /*!
+         * \brief Create SessionResources for a module and bind the module.
+         *
+         * Adds a new managed resources object to the Session for the uniquely named module.
+         * Allows the module to bind to the SignalManager and to the resources object.
+         *
+         * \param module
+         * \return non-owning pointer to created resources or nullptr for error.
+         *
+         * If the named module is already registered, calling createResources again is considered an
+         * error and nullptr is returned.
+         */
         gmxapi::SessionResources* createResources(std::shared_ptr<gmxapi::MDModule> module) noexcept;
 
         SignalManager* getSignalManager();

--- a/src/api/cpp/session-impl.h
+++ b/src/api/cpp/session-impl.h
@@ -121,6 +121,14 @@ class SessionImpl
          */
         gmxapi::SessionResources* createResources(std::shared_ptr<gmxapi::MDModule> module) noexcept;
 
+        /*!
+         * \brief Get a non-owning handle to the SignalManager for the active MD runner.
+         *
+         * Calling code is responsible for ensuring that the SessionImpl is kept alive and "open"
+         * while the returned SignalManager handle is in use.
+         *
+         * \return non-owning pointer if runner and signal manager are active, else nullptr.
+         */
         SignalManager* getSignalManager();
 
     private:

--- a/src/api/cpp/session.cpp
+++ b/src/api/cpp/session.cpp
@@ -5,19 +5,21 @@
 #include "gmxapi/session.h"
 
 #include <cassert>
-#include "gmxapi/exceptions.h"
+
+#include "gromacs/compat/make_unique.h"
+#include "gromacs/mdlib/sighandler.h"
+#include "gromacs/restraint/restraintpotential.h"
 #include "gromacs/utility/basenetwork.h"
 #include "gromacs/utility/init.h"
-#include "gmxapi/md/mdmodule.h"
-#include "gromacs/compat/make_unique.h"
-#include "gromacs/restraint/restraintpotential.h"
 
 #include "gmxapi/context.h"
+#include "gmxapi/exceptions.h"
 #include "gmxapi/status.h"
+#include "gmxapi/md/mdmodule.h"
 
+#include "mdsignals-impl.h"
 #include "session-impl.h"
 #include "sessionresources-impl.h"
-#include "mdsignals-impl.h"
 
 namespace gmxapi
 {
@@ -141,6 +143,9 @@ SessionImpl::SessionImpl(std::shared_ptr<ContextImpl> context,
     assert(context_ != nullptr);
     assert(mpiContextManager_ != nullptr);
     assert(runner_ != nullptr);
+    // For the libgromacs context, a session should explicitly reset global variables that could
+    // have been set in a previous simulation during the same process.
+    gmx_sighandler_reset();
 }
 
 Status SessionImpl::setRestraint(std::shared_ptr<gmxapi::MDModule> module)

--- a/src/api/cpp/session.cpp
+++ b/src/api/cpp/session.cpp
@@ -160,7 +160,6 @@ Status SessionImpl::setRestraint(std::shared_ptr<gmxapi::MDModule> module)
             }
             else
             {
-                restraint->bindSession(sessionResources);
                 runner_->addPullPotential(restraint, module->name());
                 status = true;
             }
@@ -205,6 +204,13 @@ gmxapi::SessionResources *SessionImpl::createResources(std::shared_ptr<gmxapi::M
         auto resourcesInstance = gmx::compat::make_unique<SessionResources>(this, module->name());
         resources_.emplace(std::make_pair(module->name(), std::move(resourcesInstance)));
         resources = resources_.at(module->name()).get();
+        // This should be more dynamic.
+        getSignalManager()->addSignaller(module->name());
+        auto restraint = module->getRestraint();
+        if (restraint)
+        {
+            restraint->bindSession(resources);
+        }
     };
     return resources;
 }

--- a/src/api/cpp/sessionresources-impl.h
+++ b/src/api/cpp/sessionresources-impl.h
@@ -1,0 +1,56 @@
+//
+// Created by Eric Irrgang on 7/10/18.
+//
+
+#ifndef GMXAPI_SESSION_RESOURCES_IMPL_H
+#define GMXAPI_SESSION_RESOURCES_IMPL_H
+
+#include <string>
+
+#include "gmxapi/md/mdsignals.h"
+
+namespace gmxapi {
+
+class SessionResources
+{
+    public:
+        /*!
+         * \brief Construct a resources object for the named operation.
+         *
+         * \param session implementation object backing these resources.
+         * \param name Unique name of workflow operation.
+         */
+        SessionResources(SessionImpl* session, std::string name);
+        SessionResources() = delete;
+
+        // Objects of this type should only exist in their Session container.
+        // If necessary, ownership can be transferred by owning through a unique_ptr handle.
+        SessionResources(const SessionResources&) = delete;
+        SessionResources& operator=(const SessionResources&) = delete;
+        SessionResources(SessionResources&&) = delete;
+        SessionResources& operator=(SessionResources&&) = delete;
+
+        ~SessionResources();
+
+        /*!
+         * \brief Get the name of the gmxapi operation for which these resources exist.
+         * \return workflow element name
+         */
+        const std::string name() const ;
+
+        Signal getMdrunnerSignal(md::signals signal);
+    private:
+        /*!
+         * \brief pointer to the session owning these resources
+         */
+        SessionImpl* sessionImpl_{nullptr};
+
+        /*!
+         * \brief name of the associated gmxapi operation
+         */
+        std::string name_;
+};
+
+} // end namespace gmxapi
+
+#endif //GMXAPI_SESSION_RESOURCES_IMPL_H

--- a/src/api/cpp/sessionresources-impl.h
+++ b/src/api/cpp/sessionresources-impl.h
@@ -5,13 +5,34 @@
 #ifndef GMXAPI_SESSION_RESOURCES_IMPL_H
 #define GMXAPI_SESSION_RESOURCES_IMPL_H
 
+/*! \file
+ * \brief Implementation details for SessionResources infrastructure.
+ *
+ * Define the library interface for classes with opaque external interfaces.
+ *
+ * These are specifically details of the gmx Mdrunner session implementation.
+ *
+ * \ingroup gmxapi
+ */
+
 #include <string>
 
 #include "gmxapi/md/mdsignals.h"
 
 namespace gmxapi {
 
-class SessionResources
+/*!
+ * \brief Consumer-specific access to Session resources.
+ *
+ * Each element of work that is managed by a Session and which may need access to Session resources
+ * is uniquely identified. SessionResources objects allow client code to be identified by the
+ * Session so that appropriate resources can be acquired when needed.
+ *
+ * Resources are configured at Session launch by SessionImpl::createResources()
+ *
+ * \ingroup gmxapi
+ */
+class SessionResources final
 {
     public:
         /*!
@@ -21,23 +42,56 @@ class SessionResources
          * \param name Unique name of workflow operation.
          */
         SessionResources(SessionImpl* session, std::string name);
+
+        /*!
+         * \brief no default constructor.
+         *
+         * \see SessionResources(SessionImpl* session, std::string name)
+         */
         SessionResources() = delete;
 
-        // Objects of this type should only exist in their Session container.
-        // If necessary, ownership can be transferred by owning through a unique_ptr handle.
+        ///@{
+        /*!
+         * \brief Not moveable or copyable.
+         *
+         * Objects of this type should only exist in their Session container.
+         * If necessary, ownership can be transferred by owning through a unique_ptr handle.
+         */
         SessionResources(const SessionResources&) = delete;
         SessionResources& operator=(const SessionResources&) = delete;
         SessionResources(SessionResources&&) = delete;
         SessionResources& operator=(SessionResources&&) = delete;
+        ///@}
 
         ~SessionResources();
 
         /*!
          * \brief Get the name of the gmxapi operation for which these resources exist.
+         *
          * \return workflow element name
          */
         const std::string name() const ;
 
+        /*!
+         * \brief Get a Signal instance implementing the requested MD signal.
+         *
+         * The caller is responsible for ensuring that the session is still active.
+         * Unfortunately, there isn't really a way to do that right now. This needs improvemnt
+         * in a near future version.
+         *
+         * Also, this is an external interface that should avoid throwing exceptions for ABI compatibility.
+         *
+         * \param signal currently must be gmxapi::md::signals::STOP
+         * \return callable object.
+         *
+         * Example:
+         *
+         *     auto signal = sessionResources->getMdrunnerSignal(md::signals::STOP);
+         *     signal();
+         *
+         * \throws gmxapi::NotImplementedError if an implementation is not available for the requested signal.
+         * \throws gmxapi::ProtocolError if the Session or Signaller is not available.
+         */
         Signal getMdrunnerSignal(md::signals signal);
     private:
         /*!

--- a/src/api/cpp/system.cpp
+++ b/src/api/cpp/system.cpp
@@ -32,8 +32,6 @@ System::System() :
 
 std::shared_ptr<Session> System::launch(std::shared_ptr<Context> context)
 {
-//    (void)context;
-//    auto session = gmx::compat::make_unique<Session>();
     return impl_->launch(std::move(context));
 }
 

--- a/src/gromacs/mdlib/sighandler.cpp
+++ b/src/gromacs/mdlib/sighandler.cpp
@@ -72,6 +72,13 @@ static volatile sig_atomic_t last_signal_name = 0;
 
 static volatile sig_atomic_t usr_condition = 0;
 
+void gmx_sighandler_reset()
+{
+    stop_condition = gmx_stop_cond_none;
+    last_signal_name = 0;
+    usr_condition = 0;
+}
+
 static void signal_handler(int n)
 {
     switch (n)

--- a/src/gromacs/mdlib/sighandler.h
+++ b/src/gromacs/mdlib/sighandler.h
@@ -77,4 +77,11 @@ const char *gmx_get_signal_name(void);
    only returns TRUE once for a single signal. */
 gmx_bool gmx_got_usr_signal(void);
 
+/*!
+ * \brief Reinitializes the machinery maintained here.
+ *
+ * Resets any signals or stop conditions currently stored in global library state.
+ */
+void gmx_sighandler_reset();
+
 #endif

--- a/src/gromacs/restraint/restraintmdmodule.cpp
+++ b/src/gromacs/restraint/restraintmdmodule.cpp
@@ -135,14 +135,14 @@ void gmx::RestraintForceProvider::calculateForces(const t_commrec          *cr,
 
     // Kludgey logging for sanity checking until we can be passed a logging facility.
     // I suppose we could use MDOutputProvider for this, but we don't necessarily want it
-    // in a log file.
-    if (int(t*1000) % 100 == 0)
-    {
-        if ((cr->dd == nullptr) || MASTER(cr))
-        {
-            std::cout << "Evaluated restraint forces on sites at " << make_vec3<real>(r1[0], r1[1], r1[2]) << " and " << make_vec3<real>(r2[0], r2[1], r2[2]) << ": " << result.force << ". rank,time: " << cr->rank_pp_intranode << "," << t << "\n";
-        }
-    }
+    // in a log file, either.
+//    if (int(t*1000) % 100 == 0)
+//    {
+//        if ((cr->dd == nullptr) || MASTER(cr))
+//        {
+//            std::cout << "Evaluated restraint forces on sites at " << make_vec3<real>(r1[0], r1[1], r1[2]) << " and " << make_vec3<real>(r2[0], r2[1], r2[2]) << ": " << result.force << ". rank,time: " << cr->rank_pp_intranode << "," << t << "\n";
+//        }
+//    }
 }
 
 gmx::RestraintMDModuleImpl::~RestraintMDModuleImpl() = default;

--- a/src/gromacs/restraint/restraintpotential.h
+++ b/src/gromacs/restraint/restraintpotential.h
@@ -45,6 +45,7 @@ struct t_pbc;
 namespace gmxapi
 {
 class Session;
+class SessionResources;
 }
 
 namespace gmx
@@ -245,21 +246,19 @@ class IRestraintPotential
         std::vector<unsigned long int> sites() const = 0;
 
         /*!
-         * \brief Allow the Mdrunner for a simulation to interact with a module.
+         * \brief Allow Session-mediated interaction with other resources or workflow elements.
          *
-         * A module implements this method to receive a handle to the runner that will be
-         * invoking the integrator to which the module is/will be attached. This allows the module
-         * to perform custom binding routines that require knowledge of or access to the runner.
-         * Other hooks include the force provider initialization and the restraint force calculation
-         * during the ForceProviders execution, which occur at lower levels.
+         * \param resources temporary access to the resources provided by the session for additional configuration.
          *
-         * \param runner
+         * A module implements this method to receive a handle to resources configured for this particular workflow
+         * element.
+         *
+         * \internal
+         * \todo This should be more general than the RestraintPotential interface.
          */
-        virtual void bindSession(gmxapi::Session* session)
+        virtual void bindSession(gmxapi::SessionResources* resources)
         {
-            // Defined in header as a temporary stop-gap to keep this interface purely public.
-            // Default: no-op.
-            (void) session;
+            (void) resources;
         }
 };
 

--- a/src/gromacs/restraint/tests/manager.cpp
+++ b/src/gromacs/restraint/tests/manager.cpp
@@ -15,6 +15,9 @@ class DummyRestraint: public gmx::IRestraintPotential
                                          gmx::Vector r2,
                                          double t) override
         {
+            (void) r1;
+            (void) r2;
+            (void) t;
             return {};
         }
 
@@ -28,7 +31,7 @@ class DummyRestraint: public gmx::IRestraintPotential
             return std::vector<unsigned long>();
         }
 
-        void bindSession(gmxapi::Session *session) override
+        void bindSession(gmxapi::SessionResources *session) override
         {
             (void)session;
         }


### PR DESCRIPTION
This PR establishes the beginnings of the C++-level Session-based
management of workflow resources, motivated by the need for a
logical signal handler between restraints and the MD simulator.

We've running into problems with our inability to map interactions
between workflow members to specific unique elements. This is
particularly problematic when trying to interpret logical operations on
the outputs of multiple bound restraints.

These changes introduce a SessionResources class to represent the
distinct interface of each distinct workflow element with the single
session. The binding interface is updated and the signalling mechanism
is reimplemented. An additional header gmxapi/session/resources.h
provides only a forward declaration of SessionResources, which is right
now used as a handle in free functions that serve as its public
interface.

A SignalManager class provides an abstraction to the signal inputs to
a gmx::Mdrunner instance.

I have also added some documentation to clarify the current simulation
launch protocols, which should be helpful in porting to the updated
design and more recent GROMACS infrastructure.