### PR TITLE
gmxapi-166 Allow upstream GROMACS and fork to be distinguished.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ before_script:
 script:
   # Note that as of gromacs-gmxapi 0.0.6, gmxapi ensemble management is not compatible with MPI-enabled gromacs-gmxapi
   - if [ "${CI_MPI}" = 0 ] ; then source $HOME/install/gromacs/bin/GMXRC && ./ci_scripts/pygmx_0_0_6.sh ; fi
-  - if [ "${CI_MPI}" = 0 ] ; then ./ci_scripts/sample_restraint.sh v0.0.6 ; fi
+  - if [ "${CI_MPI}" = 0 ] ; then ./ci_scripts/sample_restraint.sh release-0_0_6 ; fi
   - |
     if [ "${TRAVIS_BRANCH}" != master -a "${CI_MPI}" = 0 ]
         then source $HOME/install/gromacs/bin/GMXRC && ./ci_scripts/pygmx_devel.sh

--- a/README.md
+++ b/README.md
@@ -49,9 +49,19 @@ report this version through the `gmxapi::Version` interface. Client code should 
 `gmxapi/version.h` header in order to embed the constants `gmxapi::GMXAPI_MAJOR`, `gmxapi::GMXAPI_MINOR`,
 and `gmxapi::GMXAPI_PATCH` so that API compatibility checks can be performed at runtime.
 
-When a new software release is tagged, the next commit on the development branch should increment the patch level to distinguish development builds from the tagged release. As incompatibilities are introduced
-in feature branches, minor or major version number should be incremented as appropriate. At this time,
+When a new software release is tagged, the next commit on the development branch 
+should increment the patch level to distinguish development builds from the tagged release. 
+As incompatibilities are introduced
+in feature branches, minor or major version number should be incremented as appropriate. 
+At this time,
 client code has no indication of whether the version presented in a development build of gmxapi is an
-officially specified API revision or is subject to change. Developers coding against development branches
-should keep this in mind. If this becomes problematic, please offer your suggestions or propose a revision
+officially specified API revision or is subject to change. 
+Furthermore, the pre-release gmxapi in the official upstream GROMACS master branch
+may deviate from the pre-release API at the tip of the `devel` branch at
+[the Kasson Lab fork](https://github.com/kassonlab/gromacs-gmxapi) (although the
+installed `gmxapi-config.cmake` causes CMake's `find_package(gmxapi)` to set
+`gmxapi_EXPERIMENTAL=TRUE` to allow identification of the fork).
+Developers coding against development branches
+should keep this in mind. 
+If this becomes problematic, please offer your suggestions or propose a revision
 to the `gmxapi::Version` API.

--- a/ci_scripts/pygmx_0_0_6.sh
+++ b/ci_scripts/pygmx_0_0_6.sh
@@ -4,7 +4,8 @@ set -ev
 pushd $HOME
  git clone --depth=1 --no-single-branch https://github.com/kassonlab/gmxapi.git
  pushd gmxapi
-  git checkout v0.0.6
+  # Only checks the most recent patch in the 0.0.6 release branch.
+  git checkout release-0_0_6
   rm -rf build
   mkdir -p build
   pushd build

--- a/src/api/cpp/cmake/gmxapi-config.cmake.in
+++ b/src/api/cpp/cmake/gmxapi-config.cmake.in
@@ -4,3 +4,5 @@ set(gmxapi_VERSION @GMXAPI_RELEASE@)
 # where PACKAGE is "gmxapi"
 include("${CMAKE_CURRENT_LIST_DIR}/gmxapi.cmake")
 check_required_components(gmxapi)
+
+set(gmxapi_EXPERIMENTAL TRUE)


### PR DESCRIPTION
Refs kassonlab/gmxapi#166

* Set `gmxapi_EXPERIMENTAL=TRUE` CMake variable for client code using
  `find_package(gmxapi)`.
* Update CI testing to check only against the most recent commit in the
  0.0.6 client release branches (instead of specifically the tagged
  releases)
* Update notes on tasks to perform when issuing a new release.